### PR TITLE
[xyd/repo] relocate registry implementation

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,5 @@
+from .registry import Registry
+
+__all__ = [
+    'Registry',
+]

--- a/common/registry.py
+++ b/common/registry.py
@@ -1,4 +1,10 @@
-def _register_generic(module_dict, module_name, module):
+from typing import Dict
+
+def _register_generic(
+        module_dict : Dict,
+        module_name : str,
+        module : object,
+        ):
     assert module_name not in module_dict, print(
         module_name, module_dict, 'defined in several script files')
     module_dict[module_name] = module
@@ -14,23 +20,24 @@ class Registry(dict):
     >>> # registr function    
     >>> @REGISTRY_NAME.register
     >>> def foo():
-    >>>     pasa
+    >>>     pass
     
     >>> # registr class
     >>> @REGISTRY_NAME.register
     >>> class bar():
-    >>>     pasa
+    >>>     pass
 
-    >>> # fetch for class construction 
-    >>> func = REGISTRY_NAME[module_name](*args, **kwargs)
+    >>> # fetch for class construction within builder
+    >>> class_instance = REGISTRY_NAME[module_name](*args, **kwargs)
+
     >>> # fetch for function call
-    >>> obj = REGISTRY_NAME[module_name](*args, **kwargs)
+    >>> result = REGISTRY_NAME[module_name](*args, **kwargs)
     """
-    def __init__(self, name='Registry', **kwargs):
+    def __init__(self, name : str='Registry', **kwargs):
         self.name = name
         super(Registry, self).__init__(**kwargs)
 
-    def register(self, module):
+    def register(self, module : object) -> object:
         name = module.__name__
         _register_generic(self, name, module)
 


### PR DESCRIPTION
- from codriving's utils folder , to common package
  - a configurable module builder is needed by closed-loop evaluation (under `simulation` folder)